### PR TITLE
clientside Node cache can accumulate sizes of children

### DIFF
--- a/TODO
+++ b/TODO
@@ -1,6 +1,7 @@
 High Prio:
-  ☐ zip folder stream crashes with WouldBlock, something on BlockingProducer / Consumer is not right!!! @started(20-10-05 00:04)
+  ✔ zip folder stream crashes with WouldBlock, something on BlockingProducer / Consumer is not right!!! @started(20-10-05 00:04) @done(20-10-06 13:43) @lasted(1d13h39m)
   ☐ FileInfo should only show shared tick if server acknoleged it -> maybe not use vmodel?
+  ☐ reset file cache if switching from /files to /shared and between shared 
 
 Backend:
   ☐ Cache data based on hash of file name and last modified date?

--- a/backend/Rocket.toml
+++ b/backend/Rocket.toml
@@ -1,0 +1,2 @@
+[development]
+address = "0.0.0.0"

--- a/backend/src/fs/zipwriter.rs
+++ b/backend/src/fs/zipwriter.rs
@@ -33,7 +33,6 @@ pub fn new_zip_writer(path: std::path::PathBuf) -> Result<BlockingConsumer, &'st
     thread_count = ZIP_WRITER_FINISHED.wait_while(thread_count, |tc| *tc >= MAX_ZIP_WRITERS).map_err(|_| "Failed to get lock")?;
     
     *thread_count += 1;
-
     // unlock
     drop(thread_count);
     

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -4,6 +4,7 @@ import Files from '../views/Files.vue'
 import SharedList from '../views/SharedList.vue'
 import { DisplayMode, DisplayModeType, store } from '../store'
 import * as Nprogress from 'nprogress'
+import * as fs from '@/business/fs'
 
 const routes: Array<RouteRecordRaw> = [
   {
@@ -53,14 +54,18 @@ router.beforeEach(async (to, from, next) => {
   Nprogress.start()
   //console.log('to', to, to.params)
   // check if path is /shared or /files
-  if (to.path.startsWith('/files')) {
+  // if previous displayMode was diffrent (incuding diffrent shared id), reset local filesystem cache
+  if (to.path.startsWith('/files') && store.displayMode.value.mode != DisplayModeType.Files) {
+    fs.reset()
     store.displayMode.value = new DisplayMode(DisplayModeType.Files)
   } else if (to.path.startsWith('/shared')) {
     const s = to.path.split('/').filter(s => s.length > 0)
     //console.log(s)
-    if (s.length >= 2) 
+    if (s.length >= 2 && store.displayMode.value.sharedId != s[1]) {
+      fs.reset()
+      store.displayMode.value = new DisplayMode(DisplayModeType.Shared, s[1])
+    }
     
-    store.displayMode.value = new DisplayMode(DisplayModeType.Shared, s[1])
   }
 
   //TODO check if logged in


### PR DESCRIPTION
- File System updates parent file size if child was fetched
- File System cache gets resetted if changed from /files to /shared or /shared id changed